### PR TITLE
GH-6 로그인한 사용자의 식별자를 쓰레드 로컬을 활용하여 관리하도록 개선

### DIFF
--- a/src/main/java/com/example/study/common/LoginInterceptor.java
+++ b/src/main/java/com/example/study/common/LoginInterceptor.java
@@ -5,20 +5,48 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+/**
+ * 인증된 사용자만 접근 가능한 요청에 대해 세션 로그인 상태를 검사하고,
+ * 로그인된 사용자 ID를 {@link LoginMemberHolder}에 저장하는 인터셉터입니다.
+ *
+ * 요청이 끝나면 {@code ThreadLocal}에 저장된 사용자 정보를 정리합니다.
+ *
+ * <p>이 인터셉터는 컨트롤러 진입 전에 세션에 로그인 정보가 없을 경우 예외를 발생시키고,
+ * 이후 로직에서는 {@link LoginMemberContext}를 통해 사용자 ID에 접근할 수 있도록 합니다.</p>
+ */
 public class LoginInterceptor implements HandlerInterceptor {
 
     private static final String LOGIN_SESSION_KEY = "loginId";
 
+    /**
+     * 요청이 컨트롤러에 도달하기 전에 호출되며,
+     * 세션에 로그인 정보가 없을 경우 {@link UnauthenticatedException}을 발생시킵니다.
+     * 로그인 정보가 있으면 {@link LoginMemberHolder}에 사용자 ID를 저장합니다.
+     *
+     * @return {@code true}일 경우 요청 처리를 계속 진행하고,
+     *         {@code false}일 경우 처리를 중단합니다.
+     * @throws UnauthenticatedException 로그인 세션이 없거나 인증 정보가 없을 때
+     */
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-
         HttpSession session = request.getSession(false);
 
         if (session == null || session.getAttribute(LOGIN_SESSION_KEY) == null) {
             throw new UnauthenticatedException();
         }
 
-        // 로그인된 경우 → 요청 계속 진행
+        String loginId = (String) session.getAttribute(LOGIN_SESSION_KEY);
+        LoginMemberHolder.set(loginId);
         return true;
+    }
+
+    /**
+     * 요청 처리가 완료된 후 호출되며, {@link LoginMemberHolder}의 사용자 정보를 정리합니다.
+     * 쓰레드풀을 사용하는 경우, 이전 사용자 정보가 남아있는 것을 방지하기 위해 반드시 호출되어야 합니다.
+     */
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+                                Object handler, Exception ex) {
+        LoginMemberHolder.clear();
     }
 }

--- a/src/main/java/com/example/study/common/LoginMemberContext.java
+++ b/src/main/java/com/example/study/common/LoginMemberContext.java
@@ -1,0 +1,21 @@
+package com.example.study.common;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * 현재 요청 처리 중인 로그인한 사용자의 ID를 제공하는 컴포넌트입니다.
+ *
+ * {@link LoginMemberHolder}에 저장된 ThreadLocal 기반 로그인 ID를 읽기 전용으로 노출합니다.
+ * 서비스나 컨트롤러 등 애플리케이션 계층에서는 이 빈을 주입받아
+ * 직접 {@link LoginMemberHolder}를 사용하는 대신 안전하게 로그인 ID를 조회할 수 있습니다.
+ *
+ * <p><strong>주의:</strong> 이 클래스는 로그인 ID를 조회만 담당하며,
+ * 설정(set)이나 삭제(clear) 기능은 제공하지 않습니다.
+ **/
+@Component
+public class LoginMemberContext {
+
+    public String getLoginId() {
+        return LoginMemberHolder.get();
+    }
+}

--- a/src/main/java/com/example/study/common/LoginMemberHolder.java
+++ b/src/main/java/com/example/study/common/LoginMemberHolder.java
@@ -1,0 +1,35 @@
+package com.example.study.common;
+
+/**
+ * 현재 로그인한 사용자의 ID를 요청 처리 중 보관하기 위한 유틸리티 클래스입니다.
+ *
+ * <p>스레드 로컬(ThreadLocal)을 이용해 요청 처리 쓰레드마다 독립적인 사용자 정보를 저장합니다.</p>
+ * <p>요청 처리 후 반드시 {@link #clear()}를 호출해 ThreadLocal을 정리해야
+ * 메모리 누수 및 사용자 정보 오염을 방지할 수 있습니다.</p>
+ *
+ * 이 클래스는 {@code package-private} 접근 제한으로
+ * 같은 패키지 내에서만 사용하도록 설계되었습니다.
+ * 외부 패키지(예: service, controller)에서는 직접 호출하지 말고,
+ * {@link LoginMemberContext}를 통해
+ * 사용자 정보를 조회해야 합니다.
+ */
+class LoginMemberHolder {
+
+    private static final ThreadLocal<String> loginIdHolder = new ThreadLocal<>();
+
+    public static void set(String loginId) {
+        loginIdHolder.set(loginId);
+    }
+
+    public static String get() {
+        return loginIdHolder.get();
+    }
+
+    public static void clear() {
+        loginIdHolder.remove();
+    }
+
+    // 생성 금지
+    private LoginMemberHolder() {
+    }
+}

--- a/src/main/java/com/example/study/order/command/application/DeliveryAddressService.java
+++ b/src/main/java/com/example/study/order/command/application/DeliveryAddressService.java
@@ -1,5 +1,6 @@
 package com.example.study.order.command.application;
 
+import com.example.study.common.LoginMemberContext;
 import com.example.study.order.command.domain.AddressVO;
 import com.example.study.order.command.domain.DeliveryAddress;
 import com.example.study.order.command.domain.DeliveryAddressRepository;
@@ -14,15 +15,17 @@ public class DeliveryAddressService {
 
     private final DeliveryAddressRepository deliveryAddressRepository;
 
+    private final LoginMemberContext loginMemberContext;
+
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public Long saveDeliveryAddress(String memberId, DeliveryAddressDto dto) {
+    public Long saveDeliveryAddress(DeliveryAddressDto dto) {
         AddressVO addressVO = new AddressVO(
                 dto.zipCode(),
                 dto.baseAddress(),
                 dto.detailAddress()
         );
 
-        DeliveryAddress deliveryAddress = new DeliveryAddress(memberId, dto.name(), addressVO);
+        DeliveryAddress deliveryAddress = new DeliveryAddress(loginMemberContext.getLoginId(), dto.name(), addressVO);
 
         return deliveryAddressRepository.save(deliveryAddress).getId();
     }

--- a/src/main/java/com/example/study/order/ui/DeliveryAddressController.java
+++ b/src/main/java/com/example/study/order/ui/DeliveryAddressController.java
@@ -1,10 +1,10 @@
 package com.example.study.order.ui;
 
+import com.example.study.common.LoginMemberContext;
 import com.example.study.common.lock.LockTemplate;
 import com.example.study.order.command.application.DeliveryAddressDto;
 import com.example.study.order.command.application.DeliveryAddressService;
 import com.example.study.common.ApiSuccessResponse;
-import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,15 +18,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class DeliveryAddressController {
 
 	private final DeliveryAddressService deliveryAddressService;
+
 	private final LockTemplate lockTemplate;
 
+	private final LoginMemberContext loginMemberContext;
+
 	@PostMapping
-	public ApiSuccessResponse<Void> save(@Valid @RequestBody DeliveryAddressDto dto, HttpSession session) {
-		String memberId = (String) session.getAttribute("loginId");
+	public ApiSuccessResponse<Void> save(@Valid @RequestBody DeliveryAddressDto dto) {
 
-		String lockName = "deliveryAddress-lock:" + memberId;
+		String lockName = "deliveryAddress-lock:" + loginMemberContext.getLoginId();
 
-		lockTemplate.executeWithLock(lockName, () -> deliveryAddressService.saveDeliveryAddress(memberId, dto));
+		lockTemplate.executeWithLock(lockName, () -> deliveryAddressService.saveDeliveryAddress(dto));
 
 		return ApiSuccessResponse.empty();
 	}


### PR DESCRIPTION
LoginInterceptor에서 쓰레드 로컬에 로그인한 사용자의 식별자를 셋팅하여
컨트롤러나 서비스에서 꺼내올 수 있게 만들었다.
또한, 컨트롤러나 서비스에서는 LoginMemberHolder를 직접 사용하지 못하게 막고 LoginMemberContext를 사용하게 하여 잘못된 데이터가 쓰레드로컬에 셋팅되는 것을 막았다.