### PR TITLE
GH-3 DeliveryAddress 엔티티 업데이트 기능 구현

### DIFF
--- a/src/main/java/com/example/study/order/command/application/DeliveryAddressRequestDto.java
+++ b/src/main/java/com/example/study/order/command/application/DeliveryAddressRequestDto.java
@@ -1,0 +1,22 @@
+package com.example.study.order.command.application;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DeliveryAddressRequestDto (
+
+        @NotBlank(message = "id는 필수입니다.")
+        Long id,
+
+        @NotBlank(message = "배송지 이름은 필수입니다.")
+        String name,
+
+        @NotBlank(message = "우편번호는 필수입니다.")
+        String zipCode,
+
+        @NotBlank(message = "기본 주소는 필수입니다.")
+        String baseAddress,
+
+        @NotBlank(message = "상세 주소는 필수입니다.")
+        String detailAddress
+) {}
+

--- a/src/main/java/com/example/study/order/command/application/DeliveryAddressService.java
+++ b/src/main/java/com/example/study/order/command/application/DeliveryAddressService.java
@@ -29,4 +29,19 @@ public class DeliveryAddressService {
 
         return deliveryAddressRepository.save(deliveryAddress).getId();
     }
+
+    @Transactional()
+    public Long modifyDeliveryAddress(String memberId, DeliveryAddressDto dto) {
+        DeliveryAddress modifyDeliveryAddress = deliveryAddressRepository.findById(deliveryAddressRepository.findByMemberId(memberId).getId());
+
+        AddressVO addressVO = new AddressVO(
+                dto.zipCode(),
+                dto.baseAddress(),
+                dto.detailAddress()
+        );
+
+        modifyDeliveryAddress.updateDeliveryAddress(dto.name(), addressVO);
+
+        return deliveryAddressRepository.save(modifyDeliveryAddress).getId();
+    }
 }

--- a/src/main/java/com/example/study/order/command/application/DeliveryAddressService.java
+++ b/src/main/java/com/example/study/order/command/application/DeliveryAddressService.java
@@ -30,18 +30,16 @@ public class DeliveryAddressService {
         return deliveryAddressRepository.save(deliveryAddress).getId();
     }
 
-    @Transactional()
-    public Long modifyDeliveryAddress(String memberId, DeliveryAddressDto dto) {
-        DeliveryAddress modifyDeliveryAddress = deliveryAddressRepository.findById(deliveryAddressRepository.findByMemberId(memberId).getId());
+    @Transactional
+    public void modifyDeliveryAddress(DeliveryAddressRequestDto dto) {
+        DeliveryAddress modifyDeliveryAddress = deliveryAddressRepository.findById(dto.id());
 
         AddressVO addressVO = new AddressVO(
-                dto.zipCode(),
-                dto.baseAddress(),
-                dto.detailAddress()
+            dto.zipCode(),
+            dto.baseAddress(),
+            dto.detailAddress()
         );
 
         modifyDeliveryAddress.updateDeliveryAddress(dto.name(), addressVO);
-
-        return deliveryAddressRepository.save(modifyDeliveryAddress).getId();
     }
 }

--- a/src/main/java/com/example/study/order/command/domain/DeliveryAddress.java
+++ b/src/main/java/com/example/study/order/command/domain/DeliveryAddress.java
@@ -32,6 +32,11 @@ public class DeliveryAddress extends BaseUpdateEntity {
         this.address = address;
     }
 
+    public void updateDeliveryAddress(String name, AddressVO address){
+        this.name = name;
+        this.address = address;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/example/study/order/command/domain/DeliveryAddressRepository.java
+++ b/src/main/java/com/example/study/order/command/domain/DeliveryAddressRepository.java
@@ -3,4 +3,10 @@ package com.example.study.order.command.domain;
 public interface DeliveryAddressRepository {
 
     DeliveryAddress save(DeliveryAddress deliveryAddress);
+
+    DeliveryAddress findById(Long id);
+
+    DeliveryAddress modify(Long id, DeliveryAddress deliveryAddress);
+
+    DeliveryAddress findByMemberId(String memberId);
 }

--- a/src/main/java/com/example/study/order/command/domain/DeliveryAddressRepository.java
+++ b/src/main/java/com/example/study/order/command/domain/DeliveryAddressRepository.java
@@ -5,8 +5,4 @@ public interface DeliveryAddressRepository {
     DeliveryAddress save(DeliveryAddress deliveryAddress);
 
     DeliveryAddress findById(Long id);
-
-    DeliveryAddress modify(Long id, DeliveryAddress deliveryAddress);
-
-    DeliveryAddress findByMemberId(String memberId);
 }

--- a/src/main/java/com/example/study/order/command/infra/JpaDeliveryAddressRepository.java
+++ b/src/main/java/com/example/study/order/command/infra/JpaDeliveryAddressRepository.java
@@ -30,19 +30,4 @@ public class JpaDeliveryAddressRepository implements DeliveryAddressRepository {
         return Optional.ofNullable(entityManager.find(DeliveryAddress.class, id))
                 .orElseThrow(() -> new EntityNotFoundException("배송주소를 찾을 수 없습니다."));
     }
-
-    @Override
-    public DeliveryAddress modify(Long id, DeliveryAddress deliveryAddress) {
-        DeliveryAddress modifiedDeliveryAddress = findById(id);
-        modifiedDeliveryAddress.updateDeliveryAddress(deliveryAddress.getName(), deliveryAddress.getAddress());
-
-        return save(modifiedDeliveryAddress);
-    }
-
-    @Override
-    public DeliveryAddress findByMemberId(String memberId) {
-        return entityManager.createQuery("SELECT m FROM DeliveryAddress m WHERE m.memberId = :memberId", DeliveryAddress.class)
-                .setParameter("memberId", memberId)
-                .getSingleResult();
-    }
 }

--- a/src/main/java/com/example/study/order/command/infra/JpaDeliveryAddressRepository.java
+++ b/src/main/java/com/example/study/order/command/infra/JpaDeliveryAddressRepository.java
@@ -3,8 +3,11 @@ package com.example.study.order.command.infra;
 import com.example.study.order.command.domain.DeliveryAddress;
 import com.example.study.order.command.domain.DeliveryAddressRepository;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Repository
@@ -20,5 +23,26 @@ public class JpaDeliveryAddressRepository implements DeliveryAddressRepository {
         } else {
             return entityManager.merge(deliveryAddress);
         }
+    }
+
+    @Override
+    public DeliveryAddress findById(Long id) {
+        return Optional.ofNullable(entityManager.find(DeliveryAddress.class, id))
+                .orElseThrow(() -> new EntityNotFoundException("배송주소를 찾을 수 없습니다."));
+    }
+
+    @Override
+    public DeliveryAddress modify(Long id, DeliveryAddress deliveryAddress) {
+        DeliveryAddress modifiedDeliveryAddress = findById(id);
+        modifiedDeliveryAddress.updateDeliveryAddress(deliveryAddress.getName(), deliveryAddress.getAddress());
+
+        return save(modifiedDeliveryAddress);
+    }
+
+    @Override
+    public DeliveryAddress findByMemberId(String memberId) {
+        return entityManager.createQuery("SELECT m FROM DeliveryAddress m WHERE m.memberId = :memberId", DeliveryAddress.class)
+                .setParameter("memberId", memberId)
+                .getSingleResult();
     }
 }

--- a/src/main/java/com/example/study/order/ui/DeliveryAddressController.java
+++ b/src/main/java/com/example/study/order/ui/DeliveryAddressController.java
@@ -3,6 +3,7 @@ package com.example.study.order.ui;
 import com.example.study.common.LoginMemberContext;
 import com.example.study.common.lock.LockTemplate;
 import com.example.study.order.command.application.DeliveryAddressDto;
+import com.example.study.order.command.application.DeliveryAddressRequestDto;
 import com.example.study.order.command.application.DeliveryAddressService;
 import com.example.study.common.ApiSuccessResponse;
 import jakarta.validation.Valid;
@@ -31,13 +32,8 @@ public class DeliveryAddressController {
 	}
 
 	@PutMapping
-	public ApiSuccessResponse<Void> modify(@Valid @RequestBody DeliveryAddressDto dto, HttpSession session){
-		String memberId = (String) session.getAttribute("loginId");
-
-		String lockName = "deliveryAddress-lock:" + memberId;
-
-		lockTemplate.executeWithLock(lockName, () -> deliveryAddressService.modifyDeliveryAddress(memberId, dto));
-
+	public ApiSuccessResponse<Void> modify(@Valid @RequestBody DeliveryAddressRequestDto dto){
+		deliveryAddressService.modifyDeliveryAddress(dto);
 		return ApiSuccessResponse.empty();
 	}
 }

--- a/src/main/java/com/example/study/order/ui/DeliveryAddressController.java
+++ b/src/main/java/com/example/study/order/ui/DeliveryAddressController.java
@@ -7,10 +7,7 @@ import com.example.study.order.command.application.DeliveryAddressService;
 import com.example.study.common.ApiSuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -29,6 +26,17 @@ public class DeliveryAddressController {
 		String lockName = "deliveryAddress-lock:" + loginMemberContext.getLoginId();
 
 		lockTemplate.executeWithLock(lockName, () -> deliveryAddressService.saveDeliveryAddress(dto));
+
+		return ApiSuccessResponse.empty();
+	}
+
+	@PutMapping
+	public ApiSuccessResponse<Void> modify(@Valid @RequestBody DeliveryAddressDto dto, HttpSession session){
+		String memberId = (String) session.getAttribute("loginId");
+
+		String lockName = "deliveryAddress-lock:" + memberId;
+
+		lockTemplate.executeWithLock(lockName, () -> deliveryAddressService.modifyDeliveryAddress(memberId, dto));
 
 		return ApiSuccessResponse.empty();
 	}

--- a/src/test/java/com/example/study/integration/JpaDeliveryAddressRepositoryTest.java
+++ b/src/test/java/com/example/study/integration/JpaDeliveryAddressRepositoryTest.java
@@ -53,4 +53,83 @@ public class JpaDeliveryAddressRepositoryTest {
         assertThat(foundEntity.getName()).isEqualTo(saved.getName());
         assertThat(foundEntity.getAddress()).isEqualTo(saved.getAddress());
     }
+
+    @Test
+    @DisplayName("DeliveryAddress를 수정한다")
+    void updateNewDeliveryAddress() {
+
+        // given
+        UUID memberId = UUID.randomUUID();
+        AddressVO address = new AddressVO("06000", "서울 강남구", "101호");
+        DeliveryAddress deliveryAddress = new DeliveryAddress(memberId.toString(), "우리집", address);
+
+        DeliveryAddress saved = deliveryAddressRepository.save(deliveryAddress);
+
+        Long id = saved.getId();
+
+        // 영속성 컨텍스트 초기화 (flush + clear)
+        em.flush();
+        em.clear();
+
+        // given - 우편번호 변경
+        AddressVO changedZipCode = new AddressVO("44444", "서울 강남구", "101호");
+        DeliveryAddress changedZipCodeDeliveryAddress = new DeliveryAddress(memberId.toString(), "우리집", changedZipCode);
+
+        //when
+        DeliveryAddress modified = deliveryAddressRepository.modify(saved.getId(), changedZipCodeDeliveryAddress);
+
+        //then
+        DeliveryAddress foundEntity = em.find(DeliveryAddress.class, modified.getId());
+
+        assertThat(foundEntity.getName()).isEqualTo("우리집");
+        assertThat(foundEntity.getAddress().getZipCode()).isEqualTo("44444");
+        assertThat(foundEntity.getAddress().getBaseAddress()).isEqualTo("서울 강남구");
+        assertThat(foundEntity.getAddress().getDetailAddress()).isEqualTo("101호");
+
+        // given - 메인주소 변경
+        AddressVO changedBaseAddress = new AddressVO("06000", "경주 팔곡동", "101호");
+        DeliveryAddress changedBaseAddressDeliveryAddress = new DeliveryAddress(memberId.toString(), "우리집", changedBaseAddress);
+
+        //when
+        DeliveryAddress modified2 = deliveryAddressRepository.modify(saved.getId(), changedBaseAddressDeliveryAddress);
+
+        //then
+        DeliveryAddress foundEntity2 = em.find(DeliveryAddress.class, modified2.getId());
+
+        assertThat(foundEntity2.getName()).isEqualTo("우리집");
+        assertThat(foundEntity2.getAddress().getZipCode()).isEqualTo("06000");
+        assertThat(foundEntity2.getAddress().getBaseAddress()).isEqualTo("경주 팔곡동");
+        assertThat(foundEntity2.getAddress().getDetailAddress()).isEqualTo("101호");
+
+        // 서브주소 변경
+        AddressVO changedDetailAddress = new AddressVO("06000", "서울 강남구", "570호");
+        DeliveryAddress changedDetailAddressDeliveryAddress = new DeliveryAddress(memberId.toString(), "우리집", changedDetailAddress);
+
+        //when
+        DeliveryAddress modified3 = deliveryAddressRepository.modify(saved.getId(), changedDetailAddressDeliveryAddress);
+
+        //then
+        DeliveryAddress foundEntity3 = em.find(DeliveryAddress.class, modified3.getId());
+
+        assertThat(foundEntity3.getName()).isEqualTo("우리집");
+        assertThat(foundEntity3.getAddress().getZipCode()).isEqualTo("06000");
+        assertThat(foundEntity3.getAddress().getBaseAddress()).isEqualTo("서울 강남구");
+        assertThat(foundEntity3.getAddress().getDetailAddress()).isEqualTo("570호");
+
+        // 집 이름 변경
+        AddressVO changedName = new AddressVO("06000", "서울 강남구", "101호");
+        DeliveryAddress changedNameDeliveryAddress = new DeliveryAddress(memberId.toString(), "김창호의집", changedName);
+
+        //when
+        DeliveryAddress modified4 = deliveryAddressRepository.modify(saved.getId(), changedNameDeliveryAddress);
+
+        //then
+        DeliveryAddress foundEntity4 = em.find(DeliveryAddress.class, modified4.getId());
+
+        assertThat(foundEntity4.getName()).isEqualTo("김창호의집");
+        assertThat(foundEntity4.getAddress().getZipCode()).isEqualTo("06000");
+        assertThat(foundEntity4.getAddress().getBaseAddress()).isEqualTo("서울 강남구");
+        assertThat(foundEntity4.getAddress().getDetailAddress()).isEqualTo("101호");
+
+    }
 }

--- a/src/test/java/com/example/study/learningtest/DeliveryAddressTest.java
+++ b/src/test/java/com/example/study/learningtest/DeliveryAddressTest.java
@@ -1,5 +1,6 @@
-package com.example.study.integration;
+package com.example.study.learningtest;
 
+import com.example.study.integration.TestPersistenceAuditorConfig;
 import com.example.study.order.command.domain.AddressVO;
 import com.example.study.order.command.domain.DeliveryAddress;
 import com.example.study.order.command.domain.DeliveryAddressRepository;
@@ -18,7 +19,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @Import(TestPersistenceAuditorConfig.class)
 @DataJpaTest
-public class JpaDeliveryAddressRepositoryTest {
+public class DeliveryAddressTest {
 
     @Autowired
     private EntityManager em;
@@ -31,26 +32,38 @@ public class JpaDeliveryAddressRepositoryTest {
     }
 
     @Test
-    @DisplayName("DeliveryAddress 저장")
-    void saveNewDeliveryAddress() {
+    @DisplayName("DeliveryAddress를 수정한다")
+    void updateNewDeliveryAddress() {
+
         // given
         UUID memberId = UUID.randomUUID();
         AddressVO address = new AddressVO("06000", "서울 강남구", "101호");
         DeliveryAddress deliveryAddress = new DeliveryAddress(memberId.toString(), "우리집", address);
 
-        // when
         DeliveryAddress saved = deliveryAddressRepository.save(deliveryAddress);
 
         // 영속성 컨텍스트 초기화 (flush + clear)
         em.flush();
         em.clear();
 
-        // then
-        DeliveryAddress foundEntity = em.find(DeliveryAddress.class, saved.getId());
+        // given
+        AddressVO changedAdress = new AddressVO("38750", "춘천시 명동", "702호");
+        DeliveryAddress changedAdressDeliveryAddress = new DeliveryAddress(memberId.toString(), "상훈네집", changedAdress);
 
-        assertThat(foundEntity.getId()).isEqualTo(saved.getId());
-        assertThat(foundEntity.getMemberId()).isEqualTo(saved.getMemberId());
-        assertThat(foundEntity.getName()).isEqualTo(saved.getName());
-        assertThat(foundEntity.getAddress()).isEqualTo(saved.getAddress());
+        // when
+        DeliveryAddress changedEntity = deliveryAddressRepository.findById(saved.getId());
+        changedEntity.updateDeliveryAddress(changedAdressDeliveryAddress.getName(), changedAdress);
+
+        // 영속성 컨텍스트 초기화 (flush + clear)
+        em.flush();
+        em.clear();
+
+        // then
+        DeliveryAddress foundEntity = deliveryAddressRepository.findById(saved.getId());
+
+        assertThat(foundEntity.getName()).isEqualTo("상훈네집");
+        assertThat(foundEntity.getAddress().getZipCode()).isEqualTo("38750");
+        assertThat(foundEntity.getAddress().getBaseAddress()).isEqualTo("춘천시 명동");
+        assertThat(foundEntity.getAddress().getDetailAddress()).isEqualTo("702호");
     }
 }


### PR DESCRIPTION
a. null 체크해서 선택적으로 필드 업데이트
	조회시에는 조회된 id값이 없는 엔티티일경우 exception 처리

b. input 값의 엔티티를 조회한 변경값에 넣는다. 객체의 일관성이 깨지므로(캡슐화위반) setter는 지양한다. builder 로 구현 혹은 생성자로 초기화한다. 저는 생성자 사용

c. save controller와 공통되게 구현하도록 똑같이 구현