### PR TITLE
GH-12 세션을 사용하는 컨트롤러 유닛 테스트 코드 추가

### DIFF
--- a/src/main/java/com/example/study/member/command/application/MemberLoginService.java
+++ b/src/main/java/com/example/study/member/command/application/MemberLoginService.java
@@ -6,6 +6,8 @@ import com.example.study.member.command.domain.PasswordEncoder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 public class MemberLoginService {
@@ -14,9 +16,10 @@ public class MemberLoginService {
 
     private final PasswordEncoder passwordEncoder;
 
-    public Member login(MemberLoginDto memberLoginDto) {
+    public UUID login(MemberLoginDto memberLoginDto) {
         return memberRepository.findByLoginId(memberLoginDto.loginId())
                 .filter(member -> passwordEncoder.isMatch(memberLoginDto.password(), member.getPassword()))
+                .map(Member::getId)
                 .orElseThrow(InvalidCredentialsException::new);
     }
 }

--- a/src/main/java/com/example/study/member/ui/MemberLoginController.java
+++ b/src/main/java/com/example/study/member/ui/MemberLoginController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.UUID;
+
 @RestController
 @RequestMapping("/login")
 @RequiredArgsConstructor
@@ -24,8 +26,8 @@ public class MemberLoginController {
             @Valid @RequestBody MemberLoginDto dto,
             HttpSession session
     ) {
-        Member loginedMember = memberLoginService.login(dto);
-        session.setAttribute("loginId", loginedMember.getId().toString());
+        UUID loginedMemberId = memberLoginService.login(dto);
+        session.setAttribute("loginId", loginedMemberId.toString());
 
         return ApiSuccessResponse.empty();
     }

--- a/src/test/java/com/example/study/unit/MemberLoginControllerTest.java
+++ b/src/test/java/com/example/study/unit/MemberLoginControllerTest.java
@@ -1,0 +1,58 @@
+package com.example.study.unit;
+
+import com.example.study.member.command.application.MemberLoginService;
+import com.example.study.member.ui.MemberLoginController;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.springframework.http.MediaType;
+
+@WebMvcTest(MemberLoginController.class)
+class MemberLoginControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MemberLoginService memberLoginService;
+
+    @Test
+    @DisplayName("로그인 성공해서 세션에 id가 저장되고 응답은 200")
+    void loginSuccessful_storesIdInSession_ReturnsSuccess() throws Exception {
+        // given
+        UUID mockId = UUID.randomUUID();
+        given(memberLoginService.login(any())).willReturn(mockId);
+
+        // when
+        MvcResult result = mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                                "loginId": "user@example.com",
+                                "password": "password123!H"
+                            }
+                        """))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // then: 세션에 loginId 저장되었는지 확인
+        HttpSession session = result.getRequest().getSession(false);
+        assertThat(session).isNotNull();
+        assertThat(session.getAttribute("loginId")).isEqualTo(mockId.toString());
+    }
+}


### PR DESCRIPTION
- 테스트 코드를 작성하기 쉽게 MemberLoginService가 id를 리턴하게 변경.
- 세션을 사용하는 MemberLoginController의 유닛 테스트 코드 작성.
- 서비스를 목으로 사용하고 웹 계층을 띄우는 WebMvcTest를 이용하여 컨트롤러를 테스트함.