### PR TITLE
GH-36 모니터링용 도커 컴포즈 분리

### DIFF
--- a/docker-compose-monitor.yaml
+++ b/docker-compose-monitor.yaml
@@ -1,0 +1,33 @@
+version: '3.8'
+
+services:
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    networks:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=123
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+    networks:
+      - monitoring
+    depends_on:
+      - prometheus
+
+networks:
+  monitoring:
+    driver: bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,33 +16,3 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-
-  prometheus:
-    image: prom/prometheus:latest
-    container_name: prometheus
-    volumes:
-      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
-    ports:
-      - "9090:9090"
-    networks:
-      - monitoring
-
-  grafana:
-    image: grafana/grafana:latest
-    container_name: grafana
-    ports:
-      - "3000:3000"
-    environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=123
-    volumes:
-      - ./grafana/provisioning:/etc/grafana/provisioning
-      - ./grafana/dashboards:/var/lib/grafana/dashboards
-    networks:
-      - monitoring
-    depends_on:
-      - prometheus
-
-networks:
-  monitoring:
-    driver: bridge

--- a/grafana/dashboards/springboot-dashboard.json
+++ b/grafana/dashboards/springboot-dashboard.json
@@ -1,63 +1,36 @@
 {
   "id": null,
-  "uid": "springboot-dashboard",
-  "title": "Spring Boot Metrics",
-  "timezone": "browser",
+  "uid": null,
+  "title": "Spring Boot",
   "schemaVersion": 36,
   "version": 1,
   "refresh": "5s",
   "panels": [
     {
-      "type": "graph",
-      "title": "HTTP Requests",
-      "gridPos": {"x":0,"y":0,"w":12,"h":8},
+      "type": "timeseries",
+      "title": "Total Requests Per Minute",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 8 },
       "targets": [
         {
-          "expr": "http_server_requests_seconds_count{job=\"spring-boot-app\"}",
-          "legendFormat": "{{uri}}",
+          "expr": "sum(increase(http_server_requests_seconds_count[1m]))",
+          "legendFormat": "all requests",
+          "interval": "1m",
           "refId": "A"
         }
       ],
-      "datasource": "Prometheus"
-    },
-    {
-      "type": "graph",
-      "title": "Heap Memory Usage",
-      "gridPos": {"x":12,"y":0,"w":12,"h":8},
-      "targets": [
-        {
-          "expr": "jvm_memory_used_bytes{area=\"heap\"}",
-          "legendFormat": "heap",
-          "refId": "A"
+      "fieldConfig": {
+        "defaults": {
+          "unit": "req/min"
         }
-      ],
-      "datasource": "Prometheus"
-    },
-    {
-      "type": "graph",
-      "title": "Non-Heap Memory Usage",
-      "gridPos": {"x":0,"y":8,"w":12,"h":8},
-      "targets": [
-        {
-          "expr": "jvm_memory_used_bytes{area=\"nonheap\"}",
-          "legendFormat": "nonheap",
-          "refId": "A"
-        }
-      ],
-      "datasource": "Prometheus"
-    },
-    {
-      "type": "graph",
-      "title": "Active Threads",
-      "gridPos": {"x":12,"y":8,"w":12,"h":8},
-      "targets": [
-        {
-          "expr": "jvm_threads_live_threads",
-          "legendFormat": "threads",
-          "refId": "A"
-        }
-      ],
-      "datasource": "Prometheus"
+      },
+      "options": {
+        "legend": { "displayMode": "list" }
+      }
     }
-  ]
+  ],
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  }
 }


### PR DESCRIPTION

1. 1분당 1개의 점으로 총 요청 갯수 그래프를 그리게 만듬 (1분당 12개가 들어오면 12로 점을 찍는다.)
2. 그라파나와 프로메테우스는 다른 docker-compose-monitor.yaml로 바꿈