### PR TITLE
GH-69 Mysql jdbc url 옵션 미적용 문제

### DIFF
--- a/src/main/java/com/example/study/common/persistance/JdbcConnectionDetailsConfig.java
+++ b/src/main/java/com/example/study/common/persistance/JdbcConnectionDetailsConfig.java
@@ -1,0 +1,42 @@
+package com.example.study.common.persistance;
+
+import org.springframework.boot.autoconfigure.jdbc.JdbcConnectionDetails;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * Spring Boot 3.1의 ConnectionDetails 커스텀 설정 클래스.
+ *
+ * proxyBeanMethods = false 이면 @Configuration 클래스에 대한 CGLIB 프록시를 생성하지 않으므로
+ * @Bean 메서드 간 호출 기반의 싱글턴 보장은 비활성화된다.
+ *
+ * @Primary를 지정하여 Docker Compose/Testcontainers 등에서 자동 생성되는
+ * JdbcConnectionDetails 빈보다 우선 적용되도록 한다.
+ * (Spring Boot 3.1부터 ConnectionDetails는 datasource 프로퍼티(yml)보다 우선권을 가진다.)
+ */
+@Configuration(proxyBeanMethods = false)
+public class JdbcConnectionDetailsConfig {
+
+    @Bean
+    @Primary
+    public JdbcConnectionDetails jdbcConnectionDetails() {
+        return new JdbcConnectionDetails() {
+
+            @Override
+            public String getJdbcUrl() {
+                return "jdbc:mysql://localhost:3306/testdb?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true&profileSQL=true&logger=Slf4JLogger&maxQuerySizeToLog=200";
+            }
+
+            @Override
+            public String getUsername() {
+                return "testuser";
+            }
+
+            @Override
+            public String getPassword() {
+                return "testpass";
+            }
+        };
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,11 +8,6 @@ spring:
       mode: always       # schema.sql 실행
       encoding: UTF-8
 
-  datasource:
-    url: jdbc:mysql://localhost:3306/testdb?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
-    username: testuser
-    password: testpass
-    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: update                          # 애플리케이션 실행 시 DB 스키마 자동 업데이트

--- a/src/test/java/com/example/study/integration/CouponProductCouponBulkRepositoryTest.java
+++ b/src/test/java/com/example/study/integration/CouponProductCouponBulkRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.example.study.integration;
 
+import com.example.study.common.persistance.JdbcConnectionDetailsConfig;
 import com.example.study.order.couponproductcoupon.command.CouponProductCoupon;
 import com.example.study.order.couponproductcoupon.command.CouponProductCouponBulkRepository;
 import com.example.study.order.couponproductcoupon.command.CouponProductCouponBulkRepositoryImpl;
@@ -17,7 +18,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Import(TestPersistenceAuditorConfig.class)
+@Import({TestPersistenceAuditorConfig.class, JdbcConnectionDetailsConfig.class})
 @DataJpaTest
 public class CouponProductCouponBulkRepositoryTest {
 

--- a/src/test/java/com/example/study/integration/OutboxEventBulkRepositoryTest.java
+++ b/src/test/java/com/example/study/integration/OutboxEventBulkRepositoryTest.java
@@ -3,6 +3,7 @@ package com.example.study.integration;
 import com.example.study.common.event.OutboxEvent;
 import com.example.study.common.event.OutboxEventBulkRepository;
 import com.example.study.common.event.OutboxEventBulkRepositoryImpl;
+import com.example.study.common.persistance.JdbcConnectionDetailsConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +17,7 @@ import java.util.List;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @DataJpaTest
-@Import(TestPersistenceAuditorConfig.class)
+@Import({TestPersistenceAuditorConfig.class, JdbcConnectionDetailsConfig.class})
 public class OutboxEventBulkRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
Docker Compose/Testcontainers 등에서는 자동 생성되는 JdbcConnectionDetails 빈을 사용하고 datasource 프로퍼티는 무시된다. 그래서 직접 JdbcConnectionDetails를 등록해서 이걸 사용하도록 고침